### PR TITLE
Add comprehensive unit tests for agents, llm_interface and auto_config

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,310 @@
+import pytest
+from unittest.mock import MagicMock
+from ankigen.agents.token_tracker import (
+    TokenTracker,
+    get_token_tracker,
+    track_agent_usage,
+    TokenUsage,
+)
+from ankigen.agents.generators import card_dict_to_card
+from ankigen.models import Card
+
+# --- TokenTracker Tests ---
+
+
+def test_track_usage_basic():
+    tracker = TokenTracker()
+    usage = tracker.track_usage(10, 20, "gpt-4")
+
+    assert isinstance(usage, TokenUsage)
+    assert usage.prompt_tokens == 10
+    assert usage.completion_tokens == 20
+    assert usage.total_tokens == 30
+    assert usage.model == "gpt-4"
+    assert tracker.total_tokens == 30
+    assert len(tracker.usage_history) == 1
+
+
+def test_track_usage_with_cost():
+    tracker = TokenTracker()
+    cost = 0.05
+    usage = tracker.track_usage(100, 200, "gpt-4", actual_cost=cost)
+
+    assert usage.estimated_cost == cost
+    assert tracker.total_cost == cost
+    assert tracker.total_tokens == 300
+
+
+def test_get_session_summary_empty():
+    tracker = TokenTracker()
+    summary = tracker.get_session_summary()
+
+    assert summary["total_requests"] == 0
+    assert summary["total_tokens"] == 0
+    assert summary["total_cost"] == 0.0
+    assert summary["by_model"] == {}
+
+
+def test_get_session_summary_with_data():
+    tracker = TokenTracker()
+    tracker.track_usage(10, 20, "model-a", actual_cost=0.1)
+    tracker.track_usage(30, 40, "model-a", actual_cost=0.2)
+    tracker.track_usage(5, 5, "model-b", actual_cost=0.05)
+
+    summary = tracker.get_session_summary()
+
+    assert summary["total_requests"] == 3
+    assert summary["total_tokens"] == 110
+    assert pytest.approx(summary["total_cost"]) == 0.35
+
+    assert "model-a" in summary["by_model"]
+    assert summary["by_model"]["model-a"]["requests"] == 2
+    assert summary["by_model"]["model-a"]["tokens"] == 100
+    assert pytest.approx(summary["by_model"]["model-a"]["cost"]) == 0.3
+
+    assert "model-b" in summary["by_model"]
+    assert summary["by_model"]["model-b"]["requests"] == 1
+    assert summary["by_model"]["model-b"]["tokens"] == 10
+    assert pytest.approx(summary["by_model"]["model-b"]["cost"]) == 0.05
+
+
+def test_reset_session():
+    tracker = TokenTracker()
+    tracker.track_usage(10, 20, "gpt-4", actual_cost=0.1)
+    tracker.reset_session()
+
+    assert tracker.total_tokens == 0
+    assert tracker.total_cost == 0.0
+    assert len(tracker.usage_history) == 0
+
+
+def test_count_tokens_for_text():
+    tracker = TokenTracker()
+    # Non-empty text should return positive int
+    count = tracker.count_tokens_for_text("Hello world", "gpt-4")
+    assert isinstance(count, int)
+    assert count > 0
+
+    # Unknown model should fallback and still work
+    count_unknown = tracker.count_tokens_for_text("Hello world", "unknown-model")
+    assert isinstance(count_unknown, int)
+    assert count_unknown > 0
+
+
+def test_count_tokens_for_messages():
+    tracker = TokenTracker()
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello!"},
+    ]
+    count = tracker.count_tokens_for_messages(messages, "gpt-4")
+    assert isinstance(count, int)
+    assert count > 0
+
+
+def test_track_usage_from_agents_sdk():
+    tracker = TokenTracker()
+    usage_dict = {"input_tokens": 50, "output_tokens": 25, "total_tokens": 75}
+    usage = tracker.track_usage_from_agents_sdk(usage_dict, "gpt-4")
+
+    assert usage is not None
+    assert usage.prompt_tokens == 50
+    assert usage.completion_tokens == 25
+    assert usage.total_tokens == 75
+    assert tracker.total_tokens == 75
+
+
+def test_track_usage_from_agents_sdk_empty():
+    tracker = TokenTracker()
+
+    # Empty dict
+    assert tracker.track_usage_from_agents_sdk({}, "gpt-4") is None
+
+    # Zero tokens
+    usage_dict = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    assert tracker.track_usage_from_agents_sdk(usage_dict, "gpt-4") is None
+
+
+def test_track_usage_from_response():
+    tracker = TokenTracker()
+
+    # Mock response object with .usage
+    response = MagicMock()
+    response.usage.prompt_tokens = 40
+    response.usage.completion_tokens = 60
+    response.usage.total_cost = 0.02
+
+    usage = tracker.track_usage_from_response(response, "gpt-4")
+
+    assert usage.prompt_tokens == 40
+    assert usage.completion_tokens == 60
+    assert usage.estimated_cost == 0.02
+    assert tracker.total_tokens == 100
+    assert tracker.total_cost == 0.02
+
+
+def test_track_usage_from_response_different_cost_attr():
+    tracker = TokenTracker()
+
+    # Mock response object with .usage.cost instead of .total_cost
+    response = MagicMock()
+    response.usage.prompt_tokens = 10
+    response.usage.completion_tokens = 20
+    del response.usage.total_cost
+    response.usage.cost = 0.001
+
+    usage = tracker.track_usage_from_response(response, "gpt-4")
+    assert usage.estimated_cost == 0.001
+
+
+def test_track_usage_from_response_no_usage():
+    tracker = TokenTracker()
+
+    # Object without .usage
+    response = object()
+    assert tracker.track_usage_from_response(response, "gpt-4") is None
+
+
+# --- card_dict_to_card Tests ---
+
+
+def test_card_dict_to_card_basic():
+    card_data = {
+        "card_type": "basic",
+        "front": {"question": "What is Python?"},
+        "back": {
+            "answer": "A programming language.",
+            "explanation": "High-level, interpreted language.",
+            "example": "print('Hello')",
+        },
+        "metadata": {"subject": "CS", "topic": "Languages"},
+    }
+
+    card = card_dict_to_card(card_data, "Default Topic", "Default Subject")
+
+    assert isinstance(card, Card)
+    assert card.card_type == "basic"
+    assert card.front.question == "What is Python?"
+    assert card.back.answer == "A programming language."
+    assert card.metadata["subject"] == "CS"
+    assert card.metadata["topic"] == "Languages"
+
+
+def test_card_dict_to_card_cloze():
+    card_data = {
+        "card_type": "cloze",
+        "front": {"question": "Python is a {{c1::programming language}}."},
+        "back": {
+            "answer": "programming language",
+            "explanation": "Fill in the blank.",
+            "example": "",
+        },
+    }
+
+    card = card_dict_to_card(card_data, "Topic", "Subject")
+    assert card.card_type == "cloze"
+
+
+def test_card_dict_to_card_missing_front():
+    # Missing 'front' key
+    card_data = {"back": {"answer": "A"}}
+    with pytest.raises(ValueError, match="Card front must include a question field"):
+        card_dict_to_card(card_data, "T", "S")
+
+    # 'front' is not a dict
+    card_data = {"front": "What is Python?", "back": {"answer": "A"}}
+    with pytest.raises(ValueError, match="Card front must include a question field"):
+        card_dict_to_card(card_data, "T", "S")
+
+    # 'front' missing 'question'
+    card_data = {"front": {}, "back": {"answer": "A"}}
+    with pytest.raises(ValueError, match="Card front must include a question field"):
+        card_dict_to_card(card_data, "T", "S")
+
+
+def test_card_dict_to_card_missing_back():
+    card_data = {"front": {"question": "Q"}}
+    with pytest.raises(ValueError, match="Card back must include an answer field"):
+        card_dict_to_card(card_data, "T", "S")
+
+    card_data = {"front": {"question": "Q"}, "back": {}}
+    with pytest.raises(ValueError, match="Card back must include an answer field"):
+        card_dict_to_card(card_data, "T", "S")
+
+
+def test_card_dict_to_card_not_dict():
+    with pytest.raises(ValueError, match="Card payload must be a dictionary"):
+        card_dict_to_card("not a dict", "T", "S")
+
+
+def test_card_dict_to_card_default_metadata():
+    card_data = {"front": {"question": "Q"}, "back": {"answer": "A"}}
+
+    # Test fallback to defaults
+    card = card_dict_to_card(card_data, "Default Topic", "Default Subject")
+    assert card.metadata["subject"] == "Default Subject"
+    assert card.metadata["topic"] == "Default Topic"
+
+    # Test partial metadata
+    card_data["metadata"] = {"subject": "Explicit Subject"}
+    card = card_dict_to_card(card_data, "Default Topic", "Default Subject")
+    assert card.metadata["subject"] == "Explicit Subject"
+    assert card.metadata["topic"] == "Default Topic"
+
+
+# --- Module-level functions Tests ---
+
+
+def test_get_token_tracker_singleton():
+    t1 = get_token_tracker()
+    t2 = get_token_tracker()
+    assert t1 is t2
+    assert isinstance(t1, TokenTracker)
+
+
+def test_track_agent_usage():
+    tracker = get_token_tracker()
+    tracker.reset_session()
+
+    usage = track_agent_usage("Hello", "Hi there!", "gpt-4", actual_cost=0.01)
+
+    assert isinstance(usage, TokenUsage)
+    assert usage.estimated_cost == 0.01
+    assert tracker.total_cost == 0.01
+    assert len(tracker.usage_history) == 1
+    assert usage.prompt_tokens > 0
+    assert usage.completion_tokens > 0
+
+
+def test_track_usage_from_openai_response_module():
+    from ankigen.agents.token_tracker import track_usage_from_openai_response
+
+    tracker = get_token_tracker()
+    tracker.reset_session()
+
+    # Mock response object with .usage
+    response = MagicMock()
+    response.usage.prompt_tokens = 5
+    response.usage.completion_tokens = 5
+    response.usage.total_cost = 0.005
+
+    usage = track_usage_from_openai_response(response, "gpt-4")
+
+    assert usage is not None
+    assert usage.prompt_tokens == 5
+    assert tracker.total_tokens == 10
+    assert tracker.total_cost == 0.005
+
+
+def test_track_usage_from_agents_sdk_module():
+    from ankigen.agents.token_tracker import track_usage_from_agents_sdk
+
+    tracker = get_token_tracker()
+    tracker.reset_session()
+
+    usage_dict = {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+    usage = track_usage_from_agents_sdk(usage_dict, "gpt-4")
+
+    assert usage is not None
+    assert usage.prompt_tokens == 10
+    assert tracker.total_tokens == 30

--- a/tests/test_auto_config.py
+++ b/tests/test_auto_config.py
@@ -1,0 +1,201 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from ankigen.auto_config import AutoConfigService
+from ankigen.agents.schemas import AutoConfigSchema
+
+
+@pytest.fixture
+def auto_config_service():
+    return AutoConfigService()
+
+
+@pytest.fixture
+def mock_config_response():
+    return AutoConfigSchema(
+        library_search_term="pandas",
+        documentation_focus="dataframe basics",
+        topic_number=5,
+        topics_list=["t1", "t2", "t3", "t4", "t5"],
+        cards_per_topic=10,
+        learning_preferences="Focus on basics",
+        generate_cloze=True,
+        model_choice="gpt-5.2-auto",
+        subject_type="concepts",
+        scope="medium",
+        rationale="test rationale",
+    )
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_success(auto_config_service, mock_config_response):
+    mock_client = MagicMock()
+    with patch(
+        "ankigen.auto_config.structured_agent_call",
+        AsyncMock(return_value=mock_config_response),
+    ):
+        config = await auto_config_service.analyze_subject("pandas basics", mock_client)
+
+        assert config.library_search_term == "pandas"
+        assert config.topic_number == 5
+        assert len(config.topics_list) == 5
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_error_fallback(auto_config_service):
+    mock_client = MagicMock()
+    with patch(
+        "ankigen.auto_config.structured_agent_call",
+        AsyncMock(side_effect=Exception("API Error")),
+    ):
+        config = await auto_config_service.analyze_subject("any subject", mock_client)
+
+        # Check fallback values
+        assert config.topic_number == 6
+        assert len(config.topics_list) == 6
+        assert "analysis error" in config.rationale
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_with_target_count(
+    auto_config_service, mock_config_response
+):
+    mock_client = MagicMock()
+    with patch(
+        "ankigen.auto_config.structured_agent_call",
+        AsyncMock(return_value=mock_config_response),
+    ) as mock_call:
+        await auto_config_service.analyze_subject(
+            "subject", mock_client, target_topic_count=3
+        )
+
+        # Verify instructions passed to agent
+        args, kwargs = mock_call.call_args
+        assert "exactly 3 topics" in kwargs["instructions"]
+
+
+@pytest.mark.anyio
+async def test_auto_configure_success(auto_config_service, mock_config_response):
+    mock_client = MagicMock()
+    auto_config_service.context7_client.resolve_library_id = AsyncMock(
+        return_value="/pandas/docs"
+    )
+
+    with patch.object(
+        auto_config_service,
+        "analyze_subject",
+        AsyncMock(return_value=mock_config_response),
+    ):
+        ui_config = await auto_config_service.auto_configure(
+            "pandas basics", mock_client
+        )
+
+        assert ui_config["library_name"] == "pandas"
+        assert ui_config["analysis_metadata"]["context7_id"] == "/pandas/docs"
+        assert ui_config["topic_number"] == 5
+
+
+@pytest.mark.anyio
+async def test_auto_configure_empty_subject(auto_config_service):
+    mock_client = MagicMock()
+    result = await auto_config_service.auto_configure("", mock_client)
+    assert result == {}
+
+
+@pytest.mark.anyio
+async def test_auto_configure_no_library(auto_config_service, mock_config_response):
+    mock_client = MagicMock()
+    mock_config_response.library_search_term = ""
+
+    with patch.object(
+        auto_config_service,
+        "analyze_subject",
+        AsyncMock(return_value=mock_config_response),
+    ):
+        ui_config = await auto_config_service.auto_configure(
+            "general subject", mock_client
+        )
+
+        assert ui_config["library_name"] == ""
+        assert ui_config["analysis_metadata"]["library_found"] is False
+
+
+@pytest.mark.anyio
+async def test_auto_configure_context7_failure(
+    auto_config_service, mock_config_response
+):
+    mock_client = MagicMock()
+    auto_config_service.context7_client.resolve_library_id = AsyncMock(
+        side_effect=Exception("Context7 Down")
+    )
+
+    with patch.object(
+        auto_config_service,
+        "analyze_subject",
+        AsyncMock(return_value=mock_config_response),
+    ):
+        ui_config = await auto_config_service.auto_configure("pandas", mock_client)
+
+        assert ui_config["analysis_metadata"]["library_found"] is False
+        assert ui_config["library_name"] == ""
+
+
+@pytest.mark.anyio
+async def test_auto_configure_no_library_id(auto_config_service, mock_config_response):
+    mock_client = MagicMock()
+    auto_config_service.context7_client.resolve_library_id = AsyncMock(
+        return_value=None
+    )
+
+    with patch.object(
+        auto_config_service,
+        "analyze_subject",
+        AsyncMock(return_value=mock_config_response),
+    ):
+        ui_config = await auto_config_service.auto_configure("unknown lib", mock_client)
+
+        assert ui_config["analysis_metadata"]["library_found"] is False
+        assert ui_config["library_name"] == ""
+
+
+@pytest.mark.anyio
+async def test_auto_config_ui_config_structure(
+    auto_config_service, mock_config_response
+):
+    mock_client = MagicMock()
+    auto_config_service.context7_client.resolve_library_id = AsyncMock(
+        return_value="/lib/id"
+    )
+
+    with patch.object(
+        auto_config_service,
+        "analyze_subject",
+        AsyncMock(return_value=mock_config_response),
+    ):
+        ui_config = await auto_config_service.auto_configure("subject", mock_client)
+
+        expected_keys = {
+            "library_name",
+            "library_topic",
+            "topic_number",
+            "topics_list",
+            "cards_per_topic",
+            "preference_prompt",
+            "generate_cloze_checkbox",
+            "model_choice",
+            "analysis_metadata",
+        }
+        assert set(ui_config.keys()) == expected_keys
+
+        metadata_keys = {
+            "subject_type",
+            "scope",
+            "rationale",
+            "library_found",
+            "context7_id",
+        }
+        assert set(ui_config["analysis_metadata"].keys()) == metadata_keys
+
+
+@pytest.mark.anyio
+async def test_auto_config_service_init(auto_config_service):
+    assert auto_config_service.context7_client is not None

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,0 +1,203 @@
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from pydantic import BaseModel
+from ankigen.llm_interface import (
+    OpenAIClientManager,
+    structured_agent_call,
+    structured_output_completion,
+    OpenAIRateLimiter,
+    GenericJsonOutput,
+)
+
+
+class MockOutput(BaseModel):
+    field: str
+
+
+@pytest.mark.anyio
+async def test_openai_client_manager_init():
+    manager = OpenAIClientManager()
+    assert manager._client is None
+    with pytest.raises(RuntimeError, match="not initialized"):
+        manager.get_client()
+
+
+@pytest.mark.anyio
+async def test_openai_client_manager_initialize_success():
+    manager = OpenAIClientManager()
+    with patch("ankigen.llm_interface.AsyncOpenAI") as mock_async_openai:
+        await manager.initialize_client("sk-test-key")
+        assert manager.get_client() is not None
+        mock_async_openai.assert_called_once_with(api_key="sk-test-key")
+
+
+@pytest.mark.anyio
+async def test_openai_client_manager_initialize_invalid_key():
+    manager = OpenAIClientManager()
+    with pytest.raises(ValueError, match="Invalid OpenAI API key format"):
+        await manager.initialize_client("invalid-key")
+
+
+@pytest.mark.anyio
+async def test_openai_client_manager_aclose():
+    manager = OpenAIClientManager()
+    with patch("ankigen.llm_interface.AsyncOpenAI") as mock_async_openai:
+        mock_client = MagicMock()
+        mock_client.aclose = AsyncMock()
+        mock_async_openai.return_value = mock_client
+
+        await manager.initialize_client("sk-test-key")
+        await manager.aclose()
+
+        mock_client.aclose.assert_called_once()
+        assert manager._client is None
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_cached():
+    mock_client = MagicMock()
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = {"field": "cached_value"}
+
+    result = await structured_agent_call(
+        openai_client=mock_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        cache=mock_cache,
+        cache_key="key",
+    )
+
+    assert result.field == "cached_value"
+    mock_cache.get.assert_called_once_with("key", "gpt-4")
+
+
+@pytest.mark.anyio
+@pytest.mark.anyio
+async def test_structured_agent_call_success():
+    mock_client = MagicMock()
+    with (
+        patch("ankigen.llm_interface.Runner.run", new_callable=AsyncMock) as mock_run,
+        patch("ankigen.llm_interface.Agent"),
+        patch("ankigen.llm_interface.set_default_openai_client"),
+    ):
+        mock_result = MagicMock()
+        mock_result.final_output = MockOutput(field="success")
+        mock_run.return_value = mock_result
+
+        result = await structured_agent_call(
+            openai_client=mock_client,
+            model="gpt-4",
+            instructions="instr",
+            user_input="input",
+            output_type=MockOutput,
+        )
+
+        assert result.field == "success"
+        mock_run.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_retry(mocker):
+    mock_client = MagicMock()
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mocker.patch("ankigen.llm_interface.Agent")
+    mocker.patch("asyncio.sleep", AsyncMock())
+
+    mock_run = mocker.patch("ankigen.llm_interface.Runner.run", new_callable=AsyncMock)
+
+    # Fail twice, then succeed
+    mock_result = MagicMock()
+    mock_result.final_output = MockOutput(field="retry_success")
+    mock_run.side_effect = [Exception("Error 1"), Exception("Error 2"), mock_result]
+
+    result = await structured_agent_call(
+        openai_client=mock_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        retry_attempts=3,
+    )
+
+    assert result.field == "retry_success"
+    assert mock_run.call_count == 3
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_timeout(mocker):
+    mock_client = MagicMock()
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mocker.patch("ankigen.llm_interface.Agent")
+    mocker.patch("asyncio.sleep", AsyncMock())
+
+    mocker.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await structured_agent_call(
+            openai_client=mock_client,
+            model="gpt-4",
+            instructions="instr",
+            user_input="input",
+            output_type=MockOutput,
+            retry_attempts=1,
+            timeout=0.1,
+        )
+
+
+@pytest.mark.anyio
+async def test_structured_output_completion_success(mocker):
+    mock_client = MagicMock()
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+
+    mocker.patch(
+        "ankigen.llm_interface.structured_agent_call",
+        AsyncMock(return_value=GenericJsonOutput(test="data")),
+    )
+
+    result = await structured_output_completion(
+        openai_client=mock_client,
+        model="gpt-4",
+        response_format={},
+        system_prompt="sys",
+        user_prompt="user",
+        cache=mock_cache,
+    )
+
+    assert result == {"test": "data"}
+
+
+@pytest.mark.anyio
+async def test_openai_rate_limiter_no_wait(mocker):
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    mock_sleep = mocker.patch("asyncio.sleep", AsyncMock())
+
+    await limiter.wait_if_needed(50)
+    assert limiter.tokens_used_current_window == 50
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_openai_rate_limiter_wait(mocker):
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    mock_sleep = mocker.patch("asyncio.sleep", AsyncMock())
+    mock_monotonic = mocker.patch("time.monotonic")
+
+    # Start window at 1000.0
+    mock_monotonic.return_value = 1000.0
+    limiter.current_window_start_time = 1000.0
+
+    # Use 90 tokens
+    await limiter.wait_if_needed(90)
+
+    # Next request of 20 tokens should wait because 90 + 20 > 100
+    # Current time still 1000.0
+    await limiter.wait_if_needed(20)
+
+    mock_sleep.assert_called_once()
+    # Wait time should be 1000.0 + 60.0 - 1000.0 = 60.0
+    args, _ = mock_sleep.call_args
+    assert args[0] == pytest.approx(60.0)


### PR DESCRIPTION
This PR adds comprehensive unit tests for:
- `ankigen/agents/token_tracker.py` and `ankigen/agents/generators.py` (tested in `tests/test_agents.py`)
- `ankigen/llm_interface.py` (tested in `tests/test_llm_interface.py`)
- `ankigen/auto_config.py` (tested in `tests/test_auto_config.py`)

Highlights:
- 43 new unit tests across 3 files.
- Each test file has at least 10 test functions.
- All external API calls (OpenAI, Context7, Runner.run) are mocked.
- Async tests use `@pytest.mark.anyio`.
- All tests pass with no errors.
- Corrected ruff and formatting issues.
