### PR TITLE
Add comprehensive unit tests for auto_config, llm_interface, and agents modules

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from ankigen.agents.generators import (
+    card_dict_to_card,
+    SubjectExpertAgent,
+    QualityReviewAgent,
+)
+from ankigen.agents.base import parse_agent_json_response, BaseAgentWrapper, AgentConfig
+from ankigen.agents.token_tracker import TokenTracker
+from ankigen.models import Card
+
+
+@pytest.fixture
+def mock_openai_client():
+    return AsyncMock()
+
+
+def test_card_dict_to_card_basic():
+    data = {
+        "card_type": "basic",
+        "front": {"question": "q"},
+        "back": {"answer": "a", "explanation": "e", "example": "x"},
+    }
+    card = card_dict_to_card(data, "t", "s")
+    assert card.card_type == "basic"
+    assert card.front.question == "q"
+
+
+def test_card_dict_to_card_cloze():
+    data = {
+        "card_type": "cloze",
+        "front": {"question": "q {{c1::a}}"},
+        "back": {"answer": "a", "explanation": "e", "example": "x"},
+    }
+    card = card_dict_to_card(data, "t", "s")
+    assert card.card_type == "cloze"
+
+
+def test_card_dict_to_card_invalid_front():
+    with pytest.raises(ValueError):
+        card_dict_to_card({"front": {}}, "t", "s")
+
+
+def test_card_dict_to_card_invalid_back():
+    with pytest.raises(ValueError):
+        card_dict_to_card({"front": {"question": "q"}, "back": {}}, "t", "s")
+
+
+def test_parse_agent_json_response_raw():
+    assert parse_agent_json_response({"k": "v"}) == {"k": "v"}
+
+
+def test_parse_agent_json_response_markdown():
+    md = '```json\n{"k": "v"}\n```'
+    assert parse_agent_json_response(md) == {"k": "v"}
+
+
+def test_base_agent_wrapper_init(mock_openai_client):
+    config = AgentConfig(name="test", instructions="instr")
+    wrapper = BaseAgentWrapper(config, mock_openai_client)
+    assert wrapper.config.name == "test"
+
+
+def test_base_agent_wrapper_enhance_input(mock_openai_client):
+    wrapper = BaseAgentWrapper(
+        AgentConfig(name="t", instructions="i"), mock_openai_client
+    )
+    enhanced = wrapper._enhance_input_with_context("in", {"k": "v"})
+    assert "in" in enhanced and "k: v" in enhanced
+
+
+def test_subject_expert_agent_init(mock_openai_client, mocker):
+    mock_mgr = MagicMock()
+    mock_mgr.get_agent_config.return_value = AgentConfig(
+        name="subject_expert", instructions="i"
+    )
+    mocker.patch("ankigen.agents.generators.get_config_manager", return_value=mock_mgr)
+    agent = SubjectExpertAgent(mock_openai_client)
+    assert agent.openai_client == mock_openai_client
+
+
+def test_subject_expert_agent_build_batch_prompt(mock_openai_client, mocker):
+    mock_mgr = MagicMock()
+    mock_mgr.get_agent_config.return_value = AgentConfig(
+        name="subject_expert", instructions="i"
+    )
+    mocker.patch("ankigen.agents.generators.get_config_manager", return_value=mock_mgr)
+    agent = SubjectExpertAgent(mock_openai_client)
+    prompt = agent._build_batch_prompt("T", 5, 1, {"generate_cloze": True}, [])
+    assert "cloze" in prompt
+
+
+@pytest.mark.anyio
+async def test_quality_review_agent_review_success(mock_openai_client, mocker):
+    agent = QualityReviewAgent(mock_openai_client, model="gpt-4")
+    card = Card(
+        card_type="basic",
+        front={"question": "q"},
+        back={"answer": "a", "explanation": "e", "example": "x"},
+    )
+    # Use patch.object with AsyncMock
+    with patch.object(agent, "execute", new_callable=AsyncMock) as mock_exec:
+        mock_exec.return_value = (
+            {"approved": True, "reason": "ok", "revised_card": None},
+            {},
+        )
+        revised, approved, reason = await agent.review_card(card)
+        assert approved is True
+        assert revised == card
+
+
+def test_token_tracker_track_usage():
+    tracker = TokenTracker()
+    tracker.track_usage(10, 20, "m")
+    assert tracker.total_tokens == 30
+
+
+def test_token_tracker_count_tokens_for_text():
+    tracker = TokenTracker()
+    assert tracker.count_tokens_for_text("hello", "gpt-4") > 0
+
+
+def test_token_tracker_summary():
+    tracker = TokenTracker()
+    tracker.track_usage(10, 20, "m", actual_cost=0.1)
+    assert tracker.get_session_summary()["total_cost"] == 0.1

--- a/tests/test_auto_config.py
+++ b/tests/test_auto_config.py
@@ -1,0 +1,348 @@
+import pytest
+from unittest.mock import AsyncMock
+from pydantic import ValidationError
+
+from ankigen.auto_config import AutoConfigService
+from ankigen.agents.schemas import AutoConfigSchema
+
+
+@pytest.mark.anyio
+async def test_auto_configure_empty_subject():
+    """Test that auto_configure returns an empty dict for an empty subject."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    result = await service.auto_configure("", openai_client)
+    assert result == {}
+
+
+@pytest.mark.anyio
+async def test_auto_configure_whitespace_subject():
+    """Test that auto_configure returns an empty dict for a whitespace subject."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    result = await service.auto_configure("   ", openai_client)
+    assert result == {}
+
+
+@pytest.mark.anyio
+async def test_auto_configure_success_with_library(mocker):
+    """Test successful auto-configuration with a detected library."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    # Mock analyze_subject
+    mock_config = AutoConfigSchema(
+        library_search_term="pandas",
+        documentation_focus="dataframe",
+        topic_number=5,
+        topics_list=["t1", "t2", "t3", "t4", "t5"],
+        cards_per_topic=5,
+        learning_preferences="pref",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="api",
+        scope="medium",
+        rationale="rationale",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+
+    # Mock context7_client.resolve_library_id
+    mocker.patch.object(
+        service.context7_client, "resolve_library_id", return_value="/pandas/pandas"
+    )
+
+    result = await service.auto_configure("pandas basics", openai_client)
+
+    assert result["library_name"] == "pandas"
+    assert result["library_topic"] == "dataframe"
+    assert result["topic_number"] == 5
+    assert result["analysis_metadata"]["library_found"] is True
+    assert result["analysis_metadata"]["context7_id"] == "/pandas/pandas"
+
+
+@pytest.mark.anyio
+async def test_auto_configure_success_no_library(mocker):
+    """Test successful auto-configuration when no library is detected."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    # Mock analyze_subject with empty library_search_term
+    mock_config = AutoConfigSchema(
+        library_search_term="",
+        documentation_focus=None,
+        topic_number=3,
+        topics_list=["t1", "t2", "t3"],
+        cards_per_topic=5,
+        learning_preferences="pref",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="concepts",
+        scope="narrow",
+        rationale="rationale",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+
+    # Mock resolve_library_id (should not be called if library_search_term is empty,
+    # but good to mock just in case)
+    mock_resolve = mocker.patch.object(service.context7_client, "resolve_library_id")
+
+    result = await service.auto_configure("philosophy", openai_client)
+
+    assert result["library_name"] == ""
+    assert result["topic_number"] == 3
+    assert result["analysis_metadata"]["library_found"] is False
+    mock_resolve.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_auto_configure_library_not_found(mocker):
+    """Test auto-configuration when a library is detected but not found in Context7."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="nonexistent-lib",
+        documentation_focus=None,
+        topic_number=3,
+        topics_list=["t1", "t2", "t3"],
+        cards_per_topic=5,
+        learning_preferences="pref",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="api",
+        scope="narrow",
+        rationale="rationale",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+
+    # resolve_library_id returns None
+    mocker.patch.object(
+        service.context7_client, "resolve_library_id", return_value=None
+    )
+
+    result = await service.auto_configure("nonexistent-lib basics", openai_client)
+
+    assert result["library_name"] == ""
+    assert result["analysis_metadata"]["library_found"] is False
+    assert result["analysis_metadata"]["context7_id"] is None
+
+
+@pytest.mark.anyio
+async def test_auto_configure_context7_error(mocker):
+    """Test auto-configuration when Context7 client raises an exception."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="pandas",
+        documentation_focus=None,
+        topic_number=3,
+        topics_list=["t1", "t2", "t3"],
+        cards_per_topic=5,
+        learning_preferences="pref",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="api",
+        scope="narrow",
+        rationale="rationale",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+
+    # resolve_library_id raises exception
+    mocker.patch.object(
+        service.context7_client,
+        "resolve_library_id",
+        side_effect=Exception("Context7 down"),
+    )
+
+    result = await service.auto_configure("pandas basics", openai_client)
+
+    # Should handle gracefully
+    assert result["library_name"] == ""
+    assert result["analysis_metadata"]["library_found"] is False
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_success(mocker):
+    """Test successful subject analysis using the LLM."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="react",
+        documentation_focus="hooks",
+        topic_number=4,
+        topics_list=["useState", "useEffect", "useContext", "useReducer"],
+        cards_per_topic=10,
+        learning_preferences="focus on hooks",
+        generate_cloze=True,
+        model_choice="gpt-5.2-thinking",
+        subject_type="syntax",
+        scope="medium",
+        rationale="React hooks are important",
+    )
+
+    mock_call = mocker.patch(
+        "ankigen.auto_config.structured_agent_call", return_value=mock_config
+    )
+
+    result = await service.analyze_subject("React hooks tutorial", openai_client)
+
+    assert result == mock_config
+    assert mock_call.call_args[1]["output_type"] == AutoConfigSchema
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_with_topic_count_override(mocker):
+    """Test subject analysis with a target topic count override."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="",
+        documentation_focus=None,
+        topic_number=10,
+        topics_list=[f"Topic {i}" for i in range(10)],
+        cards_per_topic=5,
+        learning_preferences="pref",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="concepts",
+        scope="broad",
+        rationale="rationale",
+    )
+
+    mock_call = mocker.patch(
+        "ankigen.auto_config.structured_agent_call", return_value=mock_config
+    )
+
+    await service.analyze_subject(
+        "Computer Science", openai_client, target_topic_count=10
+    )
+
+    # Verify that the topic_count_instruction was likely included in the system prompt
+    system_prompt = mock_call.call_args[1]["instructions"]
+    assert "exactly 10 topics" in system_prompt
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_fallback_on_error(mocker):
+    """Test that analyze_subject returns fallback values on LLM error."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    mocker.patch(
+        "ankigen.auto_config.structured_agent_call", side_effect=Exception("LLM failed")
+    )
+
+    result = await service.analyze_subject("Broken Subject", openai_client)
+
+    assert result.topic_number == 6
+    assert len(result.topics_list) == 6
+    assert "Broken Subject" in result.topics_list[0]
+    assert result.rationale == "Using default settings due to analysis error"
+
+
+def test_auto_config_schema_valid():
+    """Test that AutoConfigSchema validates correct data."""
+    data = {
+        "library_search_term": "numpy",
+        "documentation_focus": "arrays",
+        "topic_number": 5,
+        "topics_list": ["intro", "creation", "indexing", "slicing", "broadcasting"],
+        "cards_per_topic": 8,
+        "learning_preferences": "focus on performance",
+        "generate_cloze": True,
+        "model_choice": "gpt-5.2-auto",
+        "subject_type": "api",
+        "scope": "medium",
+        "rationale": "Numerical computing with numpy",
+    }
+    schema = AutoConfigSchema(**data)
+    assert schema.library_search_term == "numpy"
+
+
+def test_auto_config_schema_invalid_topic_number():
+    """Test that AutoConfigSchema rejects invalid topic numbers."""
+    data = {
+        "library_search_term": "numpy",
+        "documentation_focus": "arrays",
+        "topic_number": 1,  # Too low, min is 2
+        "topics_list": ["only one"],
+        "cards_per_topic": 8,
+        "learning_preferences": "focus on performance",
+        "generate_cloze": True,
+        "model_choice": "gpt-5.2-auto",
+        "subject_type": "api",
+        "scope": "medium",
+        "rationale": "Numerical computing with numpy",
+    }
+    with pytest.raises(ValidationError):
+        AutoConfigSchema(**data)
+
+
+@pytest.mark.anyio
+async def test_auto_configure_metadata_passing(mocker):
+    """Verify that all relevant metadata is correctly passed to the UI config."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="pandas",
+        documentation_focus="plotting",
+        topic_number=4,
+        topics_list=["line", "bar", "hist", "scatter"],
+        cards_per_topic=7,
+        learning_preferences="visualization",
+        generate_cloze=False,
+        model_choice="gpt-5.2-instant",
+        subject_type="practical",
+        scope="medium",
+        rationale="Pandas plotting is useful",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+    mocker.patch.object(
+        service.context7_client, "resolve_library_id", return_value="pandas_id"
+    )
+
+    result = await service.auto_configure("pandas plotting", openai_client)
+
+    assert result["library_topic"] == "plotting"
+    assert result["cards_per_topic"] == 7
+    assert result["preference_prompt"] == "visualization"
+    assert result["generate_cloze_checkbox"] is False
+    assert result["model_choice"] == "gpt-5.2-instant"
+    assert result["analysis_metadata"]["subject_type"] == "practical"
+    assert result["analysis_metadata"]["scope"] == "medium"
+    assert result["analysis_metadata"]["rationale"] == "Pandas plotting is useful"
+
+
+@pytest.mark.anyio
+async def test_auto_configure_no_doc_focus(mocker):
+    """Test auto-configuration when documentation_focus is None."""
+    service = AutoConfigService()
+    openai_client = AsyncMock()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="flask",
+        documentation_focus=None,
+        topic_number=3,
+        topics_list=["t1", "t2", "t3"],
+        cards_per_topic=5,
+        learning_preferences="pref",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="api",
+        scope="narrow",
+        rationale="rationale",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+    mocker.patch.object(
+        service.context7_client, "resolve_library_id", return_value="flask_id"
+    )
+
+    result = await service.auto_configure("flask", openai_client)
+
+    assert result["library_topic"] == ""

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,0 +1,205 @@
+import pytest
+import asyncio
+from unittest.mock import MagicMock, AsyncMock
+from openai import AsyncOpenAI
+from pydantic import BaseModel
+
+from ankigen.llm_interface import (
+    OpenAIClientManager,
+    structured_agent_call,
+    OpenAIRateLimiter,
+    GenericJsonOutput,
+)
+from ankigen.utils import ResponseCache
+
+
+class MockOutput(BaseModel):
+    field: str
+
+
+@pytest.fixture
+def response_cache():
+    return ResponseCache(maxsize=10)
+
+
+@pytest.mark.anyio
+async def test_client_manager_init():
+    manager = OpenAIClientManager()
+    assert manager._client is None
+    assert manager._api_key is None
+
+
+@pytest.mark.anyio
+async def test_initialize_client_success(mocker):
+    manager = OpenAIClientManager()
+    mocker.patch("ankigen.llm_interface.AsyncOpenAI")
+    await manager.initialize_client("sk-valid-key")
+    assert manager._api_key == "sk-valid-key"
+    assert manager._client is not None
+
+
+@pytest.mark.anyio
+async def test_initialize_client_invalid_key():
+    manager = OpenAIClientManager()
+    with pytest.raises(ValueError):
+        await manager.initialize_client("invalid-key")
+
+
+@pytest.mark.anyio
+async def test_get_client_not_initialized():
+    manager = OpenAIClientManager()
+    with pytest.raises(RuntimeError):
+        manager.get_client()
+
+
+@pytest.mark.anyio
+async def test_get_client_success(mocker):
+    manager = OpenAIClientManager()
+    mocker.patch("ankigen.llm_interface.AsyncOpenAI")
+    await manager.initialize_client("sk-valid")
+    assert manager.get_client() is not None
+
+
+@pytest.mark.anyio
+async def test_client_context_manager(mocker):
+    mock_openai = mocker.patch("ankigen.llm_interface.AsyncOpenAI")
+    mock_instance = mock_openai.return_value
+    with OpenAIClientManager() as manager:
+        await manager.initialize_client("sk-valid")
+        assert manager.get_client() is mock_instance
+    assert manager._client is None
+
+
+@pytest.mark.anyio
+async def test_client_async_context_manager(mocker):
+    mock_openai = mocker.patch("ankigen.llm_interface.AsyncOpenAI")
+    mock_instance = mock_openai.return_value
+    mock_instance.aclose = AsyncMock()
+    async with OpenAIClientManager() as manager:
+        await manager.initialize_client("sk-valid")
+        assert manager.get_client() is mock_instance
+    assert manager._client is None
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_success(mocker):
+    openai_client = AsyncMock(spec=AsyncOpenAI)
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mock_runner = mocker.patch(
+        "ankigen.llm_interface.Runner.run", new_callable=AsyncMock
+    )
+    mock_result = MagicMock()
+    mock_result.final_output = MockOutput(field="value")
+    mock_runner.return_value = mock_result
+
+    result = await structured_agent_call(
+        openai_client=openai_client,
+        model="gpt-5.2",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+    )
+    assert result.field == "value"
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_cache_hit(mocker, response_cache):
+    openai_client = AsyncMock(spec=AsyncOpenAI)
+    response_cache.set("input", "gpt-5.2", {"field": "cached"})
+    mock_runner = mocker.patch("ankigen.llm_interface.Runner.run")
+
+    result = await structured_agent_call(
+        openai_client=openai_client,
+        model="gpt-5.2",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        cache=response_cache,
+        cache_key="input",
+    )
+    assert result.field == "cached"
+    mock_runner.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_retry_on_timeout(mocker):
+    openai_client = AsyncMock(spec=AsyncOpenAI)
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mock_runner = mocker.patch(
+        "ankigen.llm_interface.Runner.run", new_callable=AsyncMock
+    )
+    mock_runner.side_effect = [
+        asyncio.TimeoutError(),
+        MagicMock(final_output=MockOutput(field="ok")),
+    ]
+    mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    result = await structured_agent_call(
+        openai_client=openai_client,
+        model="gpt-5.2",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        retry_attempts=2,
+    )
+    assert result.field == "ok"
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_failure_after_retries(mocker):
+    openai_client = AsyncMock(spec=AsyncOpenAI)
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mock_runner = mocker.patch(
+        "ankigen.llm_interface.Runner.run", new_callable=AsyncMock
+    )
+    mock_runner.side_effect = Exception("Permanent failure")
+    mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    with pytest.raises(Exception):
+        await structured_agent_call(
+            openai_client=openai_client,
+            model="gpt-5.2",
+            instructions="instr",
+            user_input="input",
+            output_type=MockOutput,
+            retry_attempts=2,
+        )
+
+
+@pytest.mark.anyio
+async def test_rate_limiter_wait_no_delay(mocker):
+    # Use a side effect that won't exhaust
+    mocker.patch("time.monotonic", side_effect=lambda: 100.0)
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    mock_sleep = mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+    await limiter.wait_if_needed(50)
+    assert limiter.tokens_used_current_window == 50
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_rate_limiter_wait_with_delay(mocker):
+    # Controlled time jumps
+    time_values = [100.0, 100.1, 100.2, 160.3, 160.4, 160.5, 160.6, 160.7]
+    idx = 0
+
+    def get_time():
+        nonlocal idx
+        val = time_values[min(idx, len(time_values) - 1)]
+        idx += 1
+        return val
+
+    mocker.patch("time.monotonic", side_effect=get_time)
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    mock_sleep = mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    await limiter.wait_if_needed(90)
+    await limiter.wait_if_needed(20)
+
+    assert mock_sleep.called
+    assert limiter.tokens_used_current_window == 20
+
+
+def test_generic_json_output():
+    obj = GenericJsonOutput(any_field="value")
+    assert obj.model_extra["any_field"] == "value"


### PR DESCRIPTION
This PR adds comprehensive unit tests for three key modules in the AnkiGen project:
1. `ankigen/auto_config.py`: Added 12 tests for `AutoConfigService` and `AutoConfigSchema`.
2. `ankigen/llm_interface.py`: Added 15 tests for `OpenAIClientManager`, `structured_agent_call`, and `OpenAIRateLimiter`.
3. `ankigen/agents/`: Added 14 tests for `SubjectExpertAgent`, `QualityReviewAgent`, and `TokenTracker`.

All tests pass using `pytest` with `anyio`. Total 41 tests added. External API calls are properly mocked.
Verification command: `/mnt/data/Code/ankigen/.venv/bin/python -m pytest tests/test_auto_config.py tests/test_llm_interface.py tests/test_agents.py -v`