### PR TITLE
feat: add comprehensive unit tests for LLM interface, auto-config, and agents

### DIFF
--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,187 @@
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from openai import AsyncOpenAI
+from ankigen.agents.generators import (
+    SubjectExpertAgent,
+    QualityReviewAgent,
+    card_dict_to_card,
+)
+from ankigen.models import Card, CardFront, CardBack
+
+# --- card_dict_to_card Tests ---
+
+
+def test_card_dict_to_card_success():
+    data = {
+        "card_type": "basic",
+        "front": {"question": "Q?"},
+        "back": {"answer": "A", "explanation": "E", "example": "Ex"},
+        "metadata": {"subject": "math"},
+    }
+    card = card_dict_to_card(data, "topic", "subject")
+    assert card.card_type == "basic"
+    assert card.front.question == "Q?"
+    assert card.back.answer == "A"
+    assert card.metadata["subject"] == "math"
+
+
+def test_card_dict_to_card_defaults():
+    data = {"front": {"question": "Q?"}, "back": {"answer": "A"}}
+    card = card_dict_to_card(data, "Default Topic", "Default Subject")
+    assert card.card_type == "basic"
+    assert card.metadata["topic"] == "Default Topic"
+    assert card.metadata["subject"] == "Default Subject"
+
+
+def test_card_dict_to_card_invalid_payload():
+    with pytest.raises(ValueError, match="Card payload must be a dictionary"):
+        card_dict_to_card("not a dict", "t", "s")
+
+
+def test_card_dict_to_card_missing_front():
+    with pytest.raises(ValueError, match="Card front must include a question field"):
+        card_dict_to_card({"back": {"answer": "A"}}, "t", "s")
+
+
+# --- SubjectExpertAgent Tests ---
+
+
+@pytest.fixture
+def mock_openai_client():
+    return MagicMock(spec=AsyncOpenAI)
+
+
+@pytest.fixture
+def subject_expert_agent(mock_openai_client, mocker):
+    # Mock config manager
+    mock_config = MagicMock()
+    mock_config.instructions = "base instructions"
+    mock_config.custom_prompts = {"math": "math prompt"}
+    mocker.patch(
+        "ankigen.agents.generators.get_config_manager"
+    ).return_value.get_agent_config.return_value = mock_config
+
+    return SubjectExpertAgent(mock_openai_client, subject="math")
+
+
+def test_subject_expert_agent_init(subject_expert_agent):
+    assert subject_expert_agent.subject == "math"
+    assert "math prompt" in subject_expert_agent.config.instructions
+
+
+def test_subject_expert_agent_build_batch_prompt(subject_expert_agent):
+    prompt = subject_expert_agent._build_batch_prompt(
+        topic="Addition",
+        cards_in_batch=5,
+        batch_num=1,
+        context={"generate_cloze": True, "learning_preferences": "Focus on speed"},
+        previous_topics=["Numbers"],
+    )
+    assert "Generate 5 flashcards" in prompt
+    assert "Addition" in prompt
+    assert "cloze cards" in prompt
+    assert "Focus on speed" in prompt
+    assert "Numbers" in prompt
+
+
+def test_subject_expert_agent_extract_topics_for_dedup(subject_expert_agent):
+    card1 = Card(
+        front=CardFront(question="What is 1+1?"),
+        back=CardBack(answer="2", explanation="E", example="X"),
+    )
+    card2 = Card(
+        front=CardFront(question="How to multiply numbers?"),
+        back=CardBack(answer="A", explanation="E", example="X"),
+    )
+
+    topics = subject_expert_agent._extract_topics_for_dedup([card1, card2])
+    assert len(topics) == 2
+    assert "what" in topics[0].lower() or "multiply" in topics[1].lower()
+
+
+def test_subject_expert_agent_accumulate_usage(subject_expert_agent):
+    total = {"total_tokens": 100}
+    batch = {"total_tokens": 50}
+    subject_expert_agent._accumulate_usage(total, batch)
+    assert total["total_tokens"] == 150
+
+
+@pytest.mark.anyio
+async def test_subject_expert_agent_generate_cards_success(
+    subject_expert_agent, mocker
+):
+    mocker.patch.object(subject_expert_agent, "initialize", new_callable=AsyncMock)
+
+    mock_response = MagicMock()
+    mock_response.cards = [{"front": {"question": "Q1"}, "back": {"answer": "A1"}}]
+    mocker.patch.object(
+        subject_expert_agent,
+        "execute",
+        new_callable=AsyncMock,
+        return_value=(mock_response, {"total_tokens": 10}),
+    )
+
+    cards = await subject_expert_agent.generate_cards("Algebra", num_cards=1)
+    assert len(cards) == 1
+    assert cards[0].front.question == "Q1"
+
+
+# --- QualityReviewAgent Tests ---
+
+
+@pytest.fixture
+def quality_review_agent(mock_openai_client):
+    return QualityReviewAgent(mock_openai_client, model="gpt-4")
+
+
+@pytest.mark.anyio
+async def test_quality_review_agent_approve(quality_review_agent, mocker):
+    mock_card = Card(
+        card_type="basic",
+        front=CardFront(question="Q"),
+        back=CardBack(answer="A", explanation="E", example="X"),
+    )
+
+    mock_response = '{"approved": true, "reason": "Good card"}'
+    mocker.patch.object(
+        quality_review_agent,
+        "execute",
+        new_callable=AsyncMock,
+        return_value=(mock_response, {}),
+    )
+
+    revised_card, approved, reason = await quality_review_agent.review_card(mock_card)
+    assert approved is True
+    assert reason == "Good card"
+    assert revised_card is mock_card
+
+
+@pytest.mark.anyio
+async def test_quality_review_agent_revise(quality_review_agent, mocker):
+    mock_card = Card(
+        card_type="basic",
+        front=CardFront(question="Q"),
+        back=CardBack(answer="A", explanation="E", example="X"),
+        metadata={"subject": "math", "topic": "arithmetic"},
+    )
+
+    mock_response = {
+        "approved": False,
+        "reason": "Clarify",
+        "revised_card": {
+            "card_type": "basic",
+            "front": {"question": "Revised Q"},
+            "back": {"answer": "Revised A", "explanation": "E", "example": "X"},
+            "metadata": {"subject": "math", "topic": "arithmetic"},
+        },
+    }
+    mocker.patch.object(
+        quality_review_agent,
+        "execute",
+        new_callable=AsyncMock,
+        return_value=(mock_response, {}),
+    )
+
+    revised_card, approved, reason = await quality_review_agent.review_card(mock_card)
+    assert approved is False
+    assert revised_card.front.question == "Revised Q"

--- a/tests/test_auto_config.py
+++ b/tests/test_auto_config.py
@@ -1,0 +1,208 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from openai import AsyncOpenAI
+from ankigen.auto_config import AutoConfigService
+from ankigen.agents.schemas import AutoConfigSchema
+
+# --- AutoConfigService Tests ---
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_success(mocker):
+    service = AutoConfigService()
+    mock_call = mocker.patch(
+        "ankigen.auto_config.structured_agent_call", new_callable=AsyncMock
+    )
+
+    mock_config = AutoConfigSchema(
+        library_search_term="pandas",
+        documentation_focus="dataframe basics",
+        topic_number=3,
+        topics_list=["t1", "t2", "t3"],
+        cards_per_topic=5,
+        learning_preferences="prefs",
+        generate_cloze=True,
+        model_choice="gpt-5.2-auto",
+        subject_type="concepts",
+        scope="medium",
+        rationale="rat",
+    )
+    mock_call.return_value = mock_config
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    result = await service.analyze_subject("pandas basics", mock_client)
+
+    assert result.library_search_term == "pandas"
+    assert result.topic_number == 3
+    assert len(result.topics_list) == 3
+    mock_call.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_with_target_count(mocker):
+    service = AutoConfigService()
+    mock_call = mocker.patch(
+        "ankigen.auto_config.structured_agent_call", new_callable=AsyncMock
+    )
+    mock_call.return_value = MagicMock(spec=AutoConfigSchema)
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    await service.analyze_subject("pandas basics", mock_client, target_topic_count=5)
+
+    # Verify that instructions in system_prompt includes the target count
+    args, kwargs = mock_call.call_args
+    assert "You MUST set topic_number to 5" in kwargs["instructions"]
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_error_fallback(mocker):
+    service = AutoConfigService()
+    mocker.patch(
+        "ankigen.auto_config.structured_agent_call", side_effect=Exception("API Error")
+    )
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    result = await service.analyze_subject("error subject", mock_client)
+
+    assert result.topic_number == 6
+    assert result.rationale == "Using default settings due to analysis error"
+    assert "error subject" in result.topics_list[0]
+
+
+@pytest.mark.anyio
+async def test_auto_configure_empty_subject():
+    service = AutoConfigService()
+    mock_client = MagicMock(spec=AsyncOpenAI)
+
+    assert await service.auto_configure("", mock_client) == {}
+    assert await service.auto_configure("   ", mock_client) == {}
+
+
+@pytest.mark.anyio
+async def test_auto_configure_success(mocker):
+    service = AutoConfigService()
+
+    # Mock analyze_subject
+    mock_config = AutoConfigSchema(
+        library_search_term="pandas",
+        documentation_focus="df",
+        topic_number=2,
+        topics_list=["t1", "t2"],
+        cards_per_topic=10,
+        learning_preferences="prefs",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="concepts",
+        scope="medium",
+        rationale="rat",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+
+    # Mock context7_client.resolve_library_id
+    service.context7_client.resolve_library_id = AsyncMock(
+        return_value="/python/pandas"
+    )
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    result = await service.auto_configure("pandas", mock_client)
+
+    assert result["library_name"] == "pandas"
+    assert result["topic_number"] == 2
+    assert result["analysis_metadata"]["context7_id"] == "/python/pandas"
+    assert result["analysis_metadata"]["library_found"] is True
+
+
+@pytest.mark.anyio
+async def test_auto_configure_library_not_found(mocker):
+    service = AutoConfigService()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="unknown_lib",
+        documentation_focus="df",
+        topic_number=2,
+        topics_list=["t1", "t2"],
+        cards_per_topic=10,
+        learning_preferences="prefs",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="concepts",
+        scope="medium",
+        rationale="rat",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+
+    # Mock context7_client.resolve_library_id to return None
+    service.context7_client.resolve_library_id = AsyncMock(return_value=None)
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    result = await service.auto_configure("unknown", mock_client)
+
+    assert result["library_name"] == ""
+    assert result["analysis_metadata"]["library_found"] is False
+
+
+@pytest.mark.anyio
+async def test_auto_configure_context7_error(mocker):
+    service = AutoConfigService()
+
+    mocker.patch.object(
+        service, "analyze_subject", return_value=MagicMock(library_search_term="pandas")
+    )
+    service.context7_client.resolve_library_id = AsyncMock(
+        side_effect=Exception("C7 Error")
+    )
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    result = await service.auto_configure("pandas", mock_client)
+
+    assert result["analysis_metadata"]["library_found"] is False
+    assert result["analysis_metadata"]["context7_id"] is None
+
+
+def test_service_init():
+    service = AutoConfigService()
+    assert service.context7_client is not None
+
+
+@pytest.mark.anyio
+async def test_analyze_subject_call_args(mocker):
+    service = AutoConfigService()
+    mock_call = mocker.patch(
+        "ankigen.auto_config.structured_agent_call", new_callable=AsyncMock
+    )
+    mock_call.return_value = MagicMock(spec=AutoConfigSchema)
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    await service.analyze_subject("testing", mock_client)
+
+    args, kwargs = mock_call.call_args
+    assert kwargs["model"] == "gpt-5.2"
+    assert kwargs["output_type"] == AutoConfigSchema
+    assert kwargs["temperature"] == 0.3
+
+
+@pytest.mark.anyio
+async def test_auto_configure_no_library_detected(mocker):
+    service = AutoConfigService()
+
+    mock_config = AutoConfigSchema(
+        library_search_term="",  # No library
+        documentation_focus=None,
+        topic_number=2,
+        topics_list=["t1", "t2"],
+        cards_per_topic=5,
+        learning_preferences="prefs",
+        generate_cloze=False,
+        model_choice="gpt-5.2-auto",
+        subject_type="concepts",
+        scope="medium",
+        rationale="rat",
+    )
+    mocker.patch.object(service, "analyze_subject", return_value=mock_config)
+    service.context7_client.resolve_library_id = AsyncMock()
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    result = await service.auto_configure("general topic", mock_client)
+
+    assert result["library_name"] == ""
+    service.context7_client.resolve_library_id.assert_not_called()

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,0 +1,252 @@
+import asyncio
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from pydantic import BaseModel
+from openai import AsyncOpenAI
+
+from ankigen.llm_interface import (
+    OpenAIClientManager,
+    OpenAIRateLimiter,
+    structured_agent_call,
+)
+from ankigen.utils import ResponseCache
+
+# --- OpenAIClientManager Tests ---
+
+
+@pytest.mark.anyio
+async def test_initialize_client_success(mocker):
+    manager = OpenAIClientManager()
+    mock_openai = mocker.patch("ankigen.llm_interface.AsyncOpenAI")
+
+    await manager.initialize_client("sk-valid-key")
+
+    assert manager._api_key == "sk-valid-key"
+    assert manager._client is not None
+    mock_openai.assert_called_once_with(api_key="sk-valid-key")
+
+
+@pytest.mark.anyio
+async def test_initialize_client_invalid_key():
+    manager = OpenAIClientManager()
+    with pytest.raises(ValueError, match="Invalid OpenAI API key format."):
+        await manager.initialize_client("invalid-key")
+    assert manager._client is None
+
+
+@pytest.mark.anyio
+async def test_initialize_client_empty_key():
+    manager = OpenAIClientManager()
+    with pytest.raises(ValueError, match="Invalid OpenAI API key format."):
+        await manager.initialize_client("")
+    assert manager._client is None
+
+
+def test_get_client_before_init():
+    manager = OpenAIClientManager()
+    with pytest.raises(RuntimeError, match="AsyncOpenAI client is not initialized"):
+        manager.get_client()
+
+
+@pytest.mark.anyio
+async def test_get_client_after_init(mocker):
+    manager = OpenAIClientManager()
+    mocker.patch("ankigen.llm_interface.AsyncOpenAI")
+    await manager.initialize_client("sk-valid-key")
+
+    client = manager.get_client()
+    assert client is not None
+
+
+def test_context_manager_sync(mocker):
+    manager = OpenAIClientManager()
+    mock_client = MagicMock()
+    manager._client = mock_client
+
+    with manager:
+        pass
+
+    mock_client.close.assert_called_once()
+    assert manager._client is None
+
+
+@pytest.mark.anyio
+async def test_async_context_manager(mocker):
+    manager = OpenAIClientManager()
+    mock_client = AsyncMock()
+    manager._client = mock_client
+
+    async with manager:
+        pass
+
+    mock_client.aclose.assert_awaited_once()
+    assert manager._client is None
+
+
+def test_close_clears_client(mocker):
+    manager = OpenAIClientManager()
+    mock_client = MagicMock()
+    manager._client = mock_client
+
+    manager.close()
+
+    mock_client.close.assert_called_once()
+    assert manager._client is None
+
+
+# --- OpenAIRateLimiter Tests ---
+
+
+def test_init_default():
+    limiter = OpenAIRateLimiter()
+    assert limiter.tokens_per_minute_limit == 60000
+    assert limiter.tokens_used_current_window == 0
+
+
+@pytest.mark.anyio
+async def test_wait_if_needed_no_wait(mocker):
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    mock_sleep = mocker.patch("asyncio.sleep")
+
+    await limiter.wait_if_needed(50)
+    assert limiter.tokens_used_current_window == 50
+    assert mock_sleep.call_count == 0
+
+
+@pytest.mark.anyio
+async def test_wait_if_needed_exceeds_limit(mocker):
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    limiter.tokens_used_current_window = 60
+
+    mock_sleep = mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+    mocker.patch("time.monotonic", return_value=100.0)
+
+    # current_window_start_time defaults to time.monotonic() in __init__
+    limiter.current_window_start_time = 100.0
+    # 60 + 50 > 100, should wait
+    # time_to_wait = (100.0 + 60.0) - 100.0 = 60.0
+    await limiter.wait_if_needed(50)
+
+    mock_sleep.assert_awaited_once_with(pytest.approx(60.0))
+    assert limiter.tokens_used_current_window == 50
+
+
+@pytest.mark.anyio
+async def test_window_reset(mocker):
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    limiter.tokens_used_current_window = 80
+    limiter.current_window_start_time = 100.0
+
+    mocker.patch("time.monotonic", return_value=161.0)
+
+    await limiter.wait_if_needed(10)
+
+    # Window should have reset because 161 - 100 >= 60
+    assert limiter.tokens_used_current_window == 10
+    assert limiter.current_window_start_time == 161.0
+
+
+# --- structured_agent_call Tests ---
+
+
+class MockOutput(BaseModel):
+    field: str
+
+
+@pytest.mark.anyio
+async def test_cache_hit(mocker):
+    mock_cache = MagicMock(spec=ResponseCache)
+    mock_cache.get.return_value = {"field": "cached_value"}
+
+    mock_client = MagicMock(spec=AsyncOpenAI)
+
+    result = await structured_agent_call(
+        openai_client=mock_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        cache=mock_cache,
+        cache_key="test_key",
+    )
+
+    assert result.field == "cached_value"
+    mock_cache.get.assert_called_once_with("test_key", "gpt-4")
+
+
+@pytest.mark.anyio
+async def test_successful_call(mocker):
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    mock_runner = mocker.patch(
+        "ankigen.llm_interface.Runner.run", new_callable=AsyncMock
+    )
+
+    mock_result = MagicMock()
+    mock_result.final_output = MockOutput(field="success")
+    mock_runner.return_value = mock_result
+
+    result = await structured_agent_call(
+        openai_client=mock_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+    )
+
+    assert result.field == "success"
+    assert mock_runner.call_count == 1
+
+
+@pytest.mark.anyio
+async def test_retry_on_timeout(mocker):
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    mock_runner = mocker.patch(
+        "ankigen.llm_interface.Runner.run", new_callable=AsyncMock
+    )
+    mock_sleep = mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    # First call times out, second call succeeds
+    mock_result = MagicMock()
+    mock_result.final_output = MockOutput(field="success")
+
+    mock_runner.side_effect = [asyncio.TimeoutError(), mock_result]
+
+    # We need to mock asyncio.wait_for as well because structured_agent_call wraps Runner.run in wait_for
+    # Actually, Runner.run is what we're mocking, and wait_for will raise TimeoutError if we make it.
+    # But wait_for is a builtin, so we can just let it happen or mock it.
+    # Let's mock wait_for to be sure.
+    mock_wait_for = mocker.patch("asyncio.wait_for")
+    mock_wait_for.side_effect = [asyncio.TimeoutError(), mock_result]
+
+    result = await structured_agent_call(
+        openai_client=mock_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        retry_attempts=2,
+    )
+
+    assert result.field == "success"
+    assert mock_wait_for.call_count == 2
+    mock_sleep.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_raises_after_max_retries(mocker):
+    mock_client = MagicMock(spec=AsyncOpenAI)
+    mock_wait_for = mocker.patch("asyncio.wait_for")
+    mock_wait_for.side_effect = asyncio.TimeoutError()
+    mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    with pytest.raises(asyncio.TimeoutError):
+        await structured_agent_call(
+            openai_client=mock_client,
+            model="gpt-4",
+            instructions="instr",
+            user_input="input",
+            output_type=MockOutput,
+            retry_attempts=2,
+        )
+
+    assert mock_wait_for.call_count == 2


### PR DESCRIPTION
This PR adds comprehensive unit tests for `ankigen/llm_interface.py`, `ankigen/auto_config.py`, and `ankigen/agents/generators.py`.

### Changes:
- Created `tests/test_llm_interface.py` with 16 tests covering `OpenAIClientManager`, `OpenAIRateLimiter`, and `structured_agent_call`.
- Created `tests/test_auto_config.py` with 10 tests covering `AutoConfigService`.
- Created `tests/test_agents.py` with 11 tests covering `SubjectExpertAgent`, `QualityReviewAgent`, and `card_dict_to_card`.
- Ensured all async tests use `@pytest.mark.anyio`.
- Mocked all external API calls (OpenAI, Context7).
- Verified that all tests pass using `pytest`.

These tests ensure the robustness of the core LLM interaction and agentic logic in AnkiGen.