### PR TITLE
Add unit tests for llm_interface, exceptions, and ui_logic

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,85 @@
+import pytest
+from unittest.mock import MagicMock
+from ankigen.exceptions import (
+    AnkigenError,
+    ValidationError,
+    SecurityError,
+    APIError,
+    OpenAIAPIError,
+    Context7APIError,
+    ExportError,
+    CardGenerationError,
+    ConfigurationError,
+    handle_exception,
+)
+
+
+def test_exception_hierarchy():
+    assert issubclass(ValidationError, AnkigenError)
+    assert issubclass(SecurityError, AnkigenError)
+    assert issubclass(APIError, AnkigenError)
+    assert issubclass(OpenAIAPIError, APIError)
+    assert issubclass(Context7APIError, APIError)
+    assert issubclass(ExportError, AnkigenError)
+    assert issubclass(CardGenerationError, AnkigenError)
+    assert issubclass(ConfigurationError, AnkigenError)
+
+
+def test_handle_exception_reraise():
+    mock_logger = MagicMock()
+    try:
+        raise ValueError("Test error")
+    except ValueError as e:
+        with pytest.raises(ValueError, match="Test error"):
+            handle_exception(e, mock_logger, "Context message")
+
+    mock_logger.error.assert_called_once()
+    args, _ = mock_logger.error.call_args
+    assert "Context message: Test error" in args[0]
+
+
+def test_handle_exception_no_reraise():
+    mock_logger = MagicMock()
+    exc = ValueError("Test error")
+
+    handle_exception(exc, mock_logger, "Context message", reraise=False)
+
+    mock_logger.error.assert_called_once()
+
+
+def test_handle_exception_reraise_as():
+    mock_logger = MagicMock()
+    exc = ValueError("Original error")
+
+    with pytest.raises(AnkigenError, match="Context message: Original error"):
+        handle_exception(exc, mock_logger, "Context message", reraise_as=AnkigenError)
+
+
+def test_validation_error():
+    with pytest.raises(ValidationError):
+        raise ValidationError("invalid")
+
+
+def test_security_error():
+    with pytest.raises(SecurityError):
+        raise SecurityError("ssrf")
+
+
+def test_api_error():
+    with pytest.raises(APIError):
+        raise APIError("api fail")
+
+
+def test_export_error():
+    with pytest.raises(ExportError):
+        raise ExportError("export fail")
+
+
+def test_card_generation_error():
+    with pytest.raises(CardGenerationError):
+        raise CardGenerationError("gen fail")
+
+
+def test_configuration_error():
+    with pytest.raises(ConfigurationError):
+        raise ConfigurationError("config missing")

--- a/tests/test_llm_interface.py
+++ b/tests/test_llm_interface.py
@@ -1,0 +1,398 @@
+import asyncio
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+from pydantic import BaseModel
+from openai import AsyncOpenAI, OpenAIError
+
+from ankigen.llm_interface import (
+    OpenAIClientManager,
+    structured_agent_call,
+    structured_output_completion,
+    OpenAIRateLimiter,
+    GenericJsonOutput,
+)
+from ankigen.utils import ResponseCache
+
+
+# Test Pydantic model
+class MockOutput(BaseModel):
+    answer: str
+
+
+@pytest.fixture
+def mock_openai_client():
+    return MagicMock(spec=AsyncOpenAI)
+
+
+@pytest.fixture
+def response_cache():
+    return ResponseCache(maxsize=10)
+
+
+# --- OpenAIClientManager Tests ---
+
+
+@pytest.mark.anyio
+async def test_client_manager_init():
+    manager = OpenAIClientManager()
+    assert manager._client is None
+    assert manager._api_key is None
+    with pytest.raises(RuntimeError, match="not initialized"):
+        manager.get_client()
+
+
+@pytest.mark.anyio
+async def test_client_manager_initialize_valid_key(mocker):
+    mock_async_openai = mocker.patch("ankigen.llm_interface.AsyncOpenAI")
+    manager = OpenAIClientManager()
+    await manager.initialize_client("sk-valid-key")
+    assert manager._api_key == "sk-valid-key"
+    assert manager._client is not None
+    assert manager.get_client() == mock_async_openai.return_value
+
+
+@pytest.mark.anyio
+async def test_client_manager_initialize_invalid_key():
+    manager = OpenAIClientManager()
+    with pytest.raises(ValueError, match="Invalid OpenAI API key format"):
+        await manager.initialize_client("invalid-key")
+    assert manager._client is None
+
+
+@pytest.mark.anyio
+async def test_client_manager_initialize_failure(mocker):
+    mocker.patch(
+        "ankigen.llm_interface.AsyncOpenAI", side_effect=OpenAIError("API Error")
+    )
+    manager = OpenAIClientManager()
+    with pytest.raises(OpenAIError):
+        await manager.initialize_client("sk-fail")
+    assert manager._client is None
+
+
+def test_client_manager_sync_context_manager(mocker):
+    mock_close = mocker.patch.object(OpenAIClientManager, "close")
+    with OpenAIClientManager() as manager:
+        assert isinstance(manager, OpenAIClientManager)
+    mock_close.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_client_manager_async_context_manager(mocker):
+    mock_aclose = mocker.patch.object(
+        OpenAIClientManager, "aclose", new_callable=AsyncMock
+    )
+    async with OpenAIClientManager() as manager:
+        assert isinstance(manager, OpenAIClientManager)
+    mock_aclose.assert_called_once()
+
+
+def test_client_manager_close(mocker):
+    manager = OpenAIClientManager()
+    mock_client = MagicMock()
+    manager._client = mock_client
+    manager.close()
+    mock_client.close.assert_called_once()
+    assert manager._client is None
+
+
+@pytest.mark.anyio
+async def test_client_manager_aclose(mocker):
+    manager = OpenAIClientManager()
+    mock_client = AsyncMock()
+    manager._client = mock_client
+    await manager.aclose()
+    mock_client.aclose.assert_called_once()
+    assert manager._client is None
+
+
+# --- structured_agent_call Tests ---
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_cache_hit(
+    mock_openai_client, response_cache, mocker
+):
+    response_cache.set("cache_key", "gpt-4", {"answer": "cached answer"})
+    mock_runner = mocker.patch("ankigen.llm_interface.Runner.run")
+
+    result = await structured_agent_call(
+        openai_client=mock_openai_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        cache=response_cache,
+        cache_key="cache_key",
+    )
+
+    assert result.answer == "cached answer"
+    mock_runner.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_cache_miss_success(
+    mock_openai_client, response_cache, mocker
+):
+    mock_runner = mocker.patch(
+        "ankigen.llm_interface.Runner.run", new_callable=AsyncMock
+    )
+    mock_result = MagicMock()
+    mock_result.final_output = MockOutput(answer="fresh answer")
+    mock_runner.return_value = mock_result
+
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mocker.patch("ankigen.llm_interface.Agent")
+
+    result = await structured_agent_call(
+        openai_client=mock_openai_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        cache=response_cache,
+        cache_key="new_key",
+    )
+
+    assert result.answer == "fresh answer"
+    assert response_cache.get("new_key", "gpt-4") == {"answer": "fresh answer"}
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_retry_on_timeout(mock_openai_client, mocker):
+    mock_wait_for = mocker.patch("asyncio.wait_for")
+    mock_sleep = mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    mock_result = MagicMock()
+    mock_result.final_output = MockOutput(answer="retry success")
+
+    # Fail twice with timeout, then succeed
+    mock_wait_for.side_effect = [
+        asyncio.TimeoutError(),
+        asyncio.TimeoutError(),
+        mock_result,
+    ]
+
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mocker.patch("ankigen.llm_interface.Agent")
+    mocker.patch("ankigen.llm_interface.Runner.run")
+
+    result = await structured_agent_call(
+        openai_client=mock_openai_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        retry_attempts=3,
+    )
+
+    assert result.answer == "retry success"
+    assert mock_wait_for.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_timeout_exhausted(mock_openai_client, mocker):
+    mocker.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError())
+    mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mocker.patch("ankigen.llm_interface.Agent")
+    mocker.patch("ankigen.llm_interface.Runner.run")
+
+    with pytest.raises(asyncio.TimeoutError):
+        await structured_agent_call(
+            openai_client=mock_openai_client,
+            model="gpt-4",
+            instructions="instr",
+            user_input="input",
+            output_type=MockOutput,
+            retry_attempts=2,
+        )
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_generic_exception_retry(
+    mock_openai_client, mocker
+):
+    mock_runner = mocker.patch(
+        "ankigen.llm_interface.Runner.run", new_callable=AsyncMock
+    )
+    mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+
+    mock_result = MagicMock()
+
+    mock_result.final_output = MockOutput(answer="recovered")
+
+    # Fail once with Exception, then succeed
+    mock_runner.side_effect = [Exception("Random Error"), mock_result]
+
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+    mocker.patch("ankigen.llm_interface.Agent")
+
+    result = await structured_agent_call(
+        openai_client=mock_openai_client,
+        model="gpt-4",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+        retry_attempts=2,
+    )
+
+    assert result.answer == "recovered"
+    assert mock_runner.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_structured_agent_call_reasoning_effort(mock_openai_client, mocker):
+    mocker.patch("ankigen.llm_interface.Agent")
+    mock_model_settings_cls = mocker.patch("ankigen.llm_interface.ModelSettings")
+    mock_reasoning_cls = mocker.patch("openai.types.shared.Reasoning")
+
+    mocker.patch("ankigen.llm_interface.Runner.run", new_callable=AsyncMock)
+    mocker.patch("ankigen.llm_interface.set_default_openai_client")
+
+    await structured_agent_call(
+        openai_client=mock_openai_client,
+        model="gpt-5.2",
+        instructions="instr",
+        user_input="input",
+        output_type=MockOutput,
+    )
+
+    # Check that Reasoning was instantiated with effort="none"
+    mock_reasoning_cls.assert_called_once_with(effort="none")
+    # Check that ModelSettings was instantiated with reasoning
+    args, kwargs = mock_model_settings_cls.call_args
+    assert "reasoning" in kwargs
+
+
+# --- structured_output_completion Tests ---
+
+
+@pytest.mark.anyio
+async def test_structured_output_completion_success(
+    mock_openai_client, response_cache, mocker
+):
+    mock_agent_call = mocker.patch(
+        "ankigen.llm_interface.structured_agent_call", new_callable=AsyncMock
+    )
+    mock_agent_call.return_value = GenericJsonOutput(data="some data")
+
+    result = await structured_output_completion(
+        openai_client=mock_openai_client,
+        model="gpt-4",
+        response_format={},
+        system_prompt="system",
+        user_prompt="user",
+        cache=response_cache,
+    )
+
+    assert result == {"data": "some data"}
+    mock_agent_call.assert_called_once()
+    # Check instruction was appended
+    instructions = mock_agent_call.call_args.kwargs["instructions"]
+    assert "JSON object matching the specified schema" in instructions
+
+
+@pytest.mark.anyio
+async def test_structured_output_completion_no_instruction_append_if_present(
+    mock_openai_client, response_cache, mocker
+):
+    mock_agent_call = mocker.patch(
+        "ankigen.llm_interface.structured_agent_call", new_callable=AsyncMock
+    )
+
+    prompt = "Give me a JSON object matching the specified schema."
+    await structured_output_completion(
+        openai_client=mock_openai_client,
+        model="gpt-4",
+        response_format={},
+        system_prompt=prompt,
+        user_prompt="user",
+        cache=response_cache,
+    )
+
+    instructions = mock_agent_call.call_args.kwargs["instructions"]
+    # Should not be appended twice
+    assert instructions.count("JSON object matching the specified schema") == 1
+
+
+@pytest.mark.anyio
+async def test_structured_output_completion_error_propagation(
+    mock_openai_client, response_cache, mocker
+):
+    mocker.patch(
+        "ankigen.llm_interface.structured_agent_call",
+        side_effect=Exception("Agent failed"),
+    )
+
+    with pytest.raises(Exception, match="Agent failed"):
+        await structured_output_completion(
+            openai_client=mock_openai_client,
+            model="gpt-4",
+            response_format={},
+            system_prompt="system",
+            user_prompt="user",
+            cache=response_cache,
+        )
+
+
+# --- OpenAIRateLimiter Tests ---
+
+
+@pytest.mark.anyio
+async def test_rate_limiter_window_reset(mocker):
+    # Use a side_effect function to avoid StopIteration and only affect our module
+    times = [100.0, 161.0, 161.0, 161.0, 161.0]
+
+    def mock_time():
+        if times:
+            return times.pop(0)
+        return 200.0
+
+    mocker.patch("ankigen.llm_interface.time.monotonic", side_effect=mock_time)
+
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    limiter.tokens_used_current_window = 50
+    # Ensure limiter's start time is what we expect
+    limiter.current_window_start_time = 100.0
+
+    await limiter.wait_if_needed(10)
+
+    assert limiter.tokens_used_current_window == 10
+    assert limiter.current_window_start_time == 161.0
+
+
+@pytest.mark.anyio
+async def test_rate_limiter_wait_needed(mocker):
+    times = [110.0, 110.0, 160.0, 160.0, 160.0, 160.0]
+
+    def mock_time():
+        if times:
+            return times.pop(0)
+        return 200.0
+
+    mocker.patch("ankigen.llm_interface.time.monotonic", side_effect=mock_time)
+    mock_sleep = mocker.patch(
+        "ankigen.llm_interface.asyncio.sleep", new_callable=AsyncMock
+    )
+
+    limiter = OpenAIRateLimiter(tokens_per_minute=100)
+    limiter.tokens_used_current_window = 95
+    limiter.current_window_start_time = 100.0
+
+    # Request 10 tokens, exceeds 100
+    await limiter.wait_if_needed(10)
+
+    # Should wait for remaining 50s (100 + 60 - 110)
+    mock_sleep.assert_called_once_with(50.0)
+    assert limiter.tokens_used_current_window == 10
+
+
+@pytest.mark.anyio
+async def test_rate_limiter_token_counting():
+    limiter = OpenAIRateLimiter(tokens_per_minute=1000)
+    await limiter.wait_if_needed(100)
+    assert limiter.tokens_used_current_window == 100
+    await limiter.wait_if_needed(200)
+    assert limiter.tokens_used_current_window == 300

--- a/tests/test_ui_logic.py
+++ b/tests/test_ui_logic.py
@@ -1,0 +1,178 @@
+import pandas as pd
+import gradio as gr
+from ankigen.ui_logic import (
+    update_mode_visibility,
+    cards_to_dataframe,
+    dataframe_to_cards,
+)
+from ankigen.models import Card, CardFront, CardBack
+
+
+def test_update_mode_visibility():
+    result = update_mode_visibility("subject", "Math")
+
+    # 1. subject_mode (Group) - always visible
+    assert result[0] == gr.update(visible=True)
+    # 2. cards_output - always visible
+    assert result[1] == gr.update(visible=True)
+    # 3. subject textbox value
+    assert result[2] == gr.update(value="Math")
+    # 4. output DataFrame
+    assert isinstance(result[3], dict)
+    assert "value" in result[3]
+    assert isinstance(result[3]["value"], pd.DataFrame)
+    assert "Topic" in result[3]["value"].columns
+    # 5. total_cards_html
+    assert result[4] == gr.update(
+        value="<div><b>Total Cards Generated:</b> <span id='total-cards-count'>0</span></div>",
+        visible=False,
+    )
+
+
+def test_cards_to_dataframe():
+    card = Card(
+        front=CardFront(question="Front 1"),
+        back=CardBack(answer="Back 1", explanation="Expl", example="Ex"),
+        metadata={"tags": ["tag1", "tag2"], "topic": "Math", "source_url": "url"},
+        card_type="Cloze",
+    )
+
+    df = cards_to_dataframe([card])
+
+    assert len(df) == 1
+    assert df.iloc[0]["Front"] == "Front 1"
+    assert df.iloc[0]["Back"] == "Back 1"
+    assert df.iloc[0]["Tags"] == "tag1, tag2"
+    assert df.iloc[0]["Topic"] == "Math"
+    assert df.iloc[0]["Card Type"] == "Cloze"
+    assert df.iloc[0]["Source_URL"] == "url"
+
+
+def test_cards_to_dataframe_empty():
+    df = cards_to_dataframe([])
+    assert df.empty
+    assert list(df.columns) == [
+        "ID",
+        "Topic",
+        "Front",
+        "Back",
+        "Tags",
+        "Card Type",
+        "Explanation",
+        "Example",
+        "Source_URL",
+    ]
+
+
+def test_dataframe_to_cards():
+    original_card = Card(
+        front=CardFront(question="Old Q"),
+        back=CardBack(answer="Old A", explanation="Old E", example="Old X"),
+        metadata={"tags": ["old"], "topic": "Old Topic"},
+        card_type="basic",
+    )
+
+    df = pd.DataFrame(
+        [
+            {
+                "ID": 1,
+                "Topic": "New Topic",
+                "Front": "New Q",
+                "Back": "New A",
+                "Tags": "new1, new2",
+                "Card Type": "cloze",
+                "Explanation": "New E",
+                "Example": "New X",
+            }
+        ]
+    )
+
+    updated_cards = dataframe_to_cards(df, [original_card])
+
+    assert len(updated_cards) == 1
+    new_card = updated_cards[0]
+    assert new_card.front.question == "New Q"
+    assert new_card.back.answer == "New A"
+    assert new_card.back.explanation == "New E"
+    assert new_card.metadata["topic"] == "New Topic"
+    assert new_card.metadata["tags"] == ["new1", "new2"]
+    assert new_card.card_type == "cloze"
+
+
+def test_dataframe_to_cards_empty_df():
+    original_cards = [
+        Card(
+            front=CardFront(question="Q"),
+            back=CardBack(answer="A", explanation="E", example="X"),
+        )
+    ]
+    assert dataframe_to_cards(pd.DataFrame(), original_cards) == []
+
+
+def test_dataframe_to_cards_out_of_bounds():
+    df = pd.DataFrame([{"ID": 5, "Front": "Invalid"}])
+    assert dataframe_to_cards(df, []) == []
+
+
+def test_cards_to_dataframe_various_types():
+    cards = [
+        Card(
+            front=CardFront(question="Q1"),
+            back=CardBack(answer="A1", explanation="E1", example="X1"),
+            card_type="Basic",
+        ),
+        Card(
+            front=CardFront(question="Q2"),
+            back=CardBack(answer="A2", explanation="E2", example="X2"),
+            card_type="Cloze",
+        ),
+    ]
+    df = cards_to_dataframe(cards)
+    assert len(df) == 2
+    assert df.iloc[0]["Card Type"] == "Basic"
+    assert df.iloc[1]["Card Type"] == "Cloze"
+
+
+def test_cards_to_dataframe_no_metadata():
+    card = Card(
+        front=CardFront(question="Q"),
+        back=CardBack(answer="A", explanation="E", example="X"),
+    )
+    df = cards_to_dataframe([card])
+    assert df.iloc[0]["Topic"] == "N/A"
+    assert df.iloc[0]["Tags"] == ""
+
+
+def test_dataframe_to_cards_missing_columns():
+    original_card = Card(
+        front=CardFront(question="Q"),
+        back=CardBack(answer="A", explanation="E", example="X"),
+    )
+    df = pd.DataFrame([{"ID": 1}])  # Only ID
+    updated_cards = dataframe_to_cards(df, [original_card])
+    assert len(updated_cards) == 1
+    # Should use defaults from original_card
+    assert updated_cards[0].front.question == "Q"
+
+
+def test_dataframe_to_cards_multiple():
+    cards = [
+        Card(
+            front=CardFront(question="Q1"),
+            back=CardBack(answer="A1", explanation="E1", example="X1"),
+        ),
+        Card(
+            front=CardFront(question="Q2"),
+            back=CardBack(answer="A2", explanation="E2", example="X2"),
+        ),
+    ]
+    df = pd.DataFrame(
+        [
+            {"ID": 1, "Front": "U1"},
+            {"ID": 2, "Front": "U2"},
+        ]
+    )
+    updated = dataframe_to_cards(df, cards)
+    assert len(updated) == 2
+    assert updated[0].front.question == "U1"
+    assert updated[1].front.question == "U2"


### PR DESCRIPTION
This PR adds comprehensive unit tests for `ankigen/llm_interface.py`, `ankigen/exceptions.py`, and `ankigen/ui_logic.py`.

### Changes:
- Created `tests/test_llm_interface.py` with 20 tests covering:
    - `OpenAIClientManager`
    - `structured_agent_call` (cache, retry, etc.)
    - `structured_output_completion`
    - `OpenAIRateLimiter`
- Created `tests/test_exceptions.py` with 10 tests covering the exception hierarchy and `handle_exception`.
- Created `tests/test_ui_logic.py` with 10 tests covering UI state updates and card/dataframe conversions.

### Verification:
- All tests pass with `uv run pytest tests/ -v`.
- All external calls are mocked.
- Met the requirement of at least 10 tests per file.